### PR TITLE
Makes the output directory configurable via `--output`

### DIFF
--- a/sphinxserve/lib.py
+++ b/sphinxserve/lib.py
@@ -44,8 +44,11 @@ class Webserver(object):
             ws.onclose = function() {    // reload server signal
                 window.location.reload(true)}
         </script>''')
-        app = Flask(__name__, static_url_path='',
-            static_folder=self.path + '/html')
+        app = Flask(
+            __name__,
+            static_url_path='',
+            static_folder=self.path
+        )
         sockets = Sockets(app)
 
         @app.route('/')


### PR DESCRIPTION
Adds the ability for one to specify the directory to which output files will be written to and served from by specifying a single command-line argument `--output=/path/to/files`.

The reason _I'm_ in need of this is that I have my notes in a DropBox folder, but there really isn't any need for synchronizing the generated files, so I can specify that the output be written to `/tmp/notes/`, for example.
