### PR TITLE
Switch to spawning a subprocess for document build; minor logging changes.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ gevent>=1.1.1
 loadconfig>=0.1.1
 sphinx>=1.2.3
 watchdog>=0.8.3
+coloredlogs==5.0

--- a/sphinxserve/__init__.py
+++ b/sphinxserve/__init__.py
@@ -131,11 +131,7 @@ class SphinxServer(object):
         '''
         with fs_event_ctx(self.c.sphinx_path, self.c.extensions) as fs_ev_iter:
             for event in fs_ev_iter:
-                logger.info(
-                    '%s %s',
-                    event,
-                    event.ev_name,
-                )
+                logger.info('%s %s', event, event.ev_name)
                 self.watch_ev.set()
 
     def render(self):

--- a/sphinxserve/__init__.py
+++ b/sphinxserve/__init__.py
@@ -12,7 +12,6 @@ gevent.monkey.patch_all()
 import logging
 import os
 import shlex
-import subprocess
 import sys
 from textwrap import dedent
 import time
@@ -194,17 +193,6 @@ class Prog(object):
     def check_dependencies(self):
         '''Create sphinx conf.py and index.rst if necessary'''
         path = self.c.sphinx_path
-
-        sphinx_bin_path = subprocess.check_output([
-            'which',
-            'sphinx-build',
-        ]).strip()
-        if not sphinx_bin_path:
-            raise SystemError(
-                "`sphinx-build` not found; Is the sphinx python "
-                "package installed?"
-            )
-        self.c.sphinx_bin_path = sphinx_bin_path
 
         if not os.path.exists(path):
             os.makedirs(path)

--- a/sphinxserve/__init__.py
+++ b/sphinxserve/__init__.py
@@ -124,11 +124,7 @@ class SphinxServer(object):
             port,
             self.render_ev
         )
-        logger.info(
-            "Listening on http://%s:%s",
-            host,
-            port,
-        )
+        logger.info("Listening on http://%s:%s", host, port)
         server.run()
 
     def watch(self):

--- a/sphinxserve/__init__.py
+++ b/sphinxserve/__init__.py
@@ -6,6 +6,9 @@ usage: sphinxserve [-h] {serve,install,uninstall} ...'''
 
 __version__ = '0.8b1'
 __author__ = 'Daniel Mizyrycki'
+import gevent.monkey
+gevent.monkey.patch_all()
+
 import logging
 import os
 import shlex
@@ -17,12 +20,9 @@ import time
 import coloredlogs
 from gevent import spawn, joinall
 from gevent.event import Event
-import gevent.monkey
 from loadconfig import Config
 from loadconfig.lib import run, write_file
 from sphinxserve.lib import fs_event_ctx, Webserver
-
-gevent.monkey.patch_all()
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
1.  Simplifies the build process to instead launch the sphinx compiler via a subprocess.  Due to the way sphinx registers extensions, `sphinx.build_main` will end up processing extensions once for every time it is invoked (which means that if you leave `sphinxserve` running for a while, you'll eventually end up processing extensions once for each file that was changed since you started `sphinxserve` every time a file is changed, and thus will see a lot of reported warnings and duplicated header elements in the generated documents).  This fixes that.
2. Logging clarifications and updates.  Logs any application-specific messages to a module-level logger which is itself routed to the console to display things like what files have been changed and when a build was completed or whatnot.  You can continue to route _all_ logging messages to the console using `--debug` as it exists today, and can silence even the messages that will appear by default now by choosing a higher-than-default `--loglevel`.  And as a little side-benefit, it (optionally) colorizes the output to make it clear when things have gone wrong (see below screenshot).
3. Changes a few lines to satisfy PEP-8; mostly just moving imports around to be in the order PEP-8 specifies, but also fixes one place in which a logging message was directly interpolated (logging messages, unlike you would usually do with a string, are not supposed to be built using `.format` or `%`, and you're instead supposed to pass the message parameters as extra arguments; there are non-obvious but legitimate reasons for this that I can go into in more depth if you're curious).
