### PR TITLE
Skip decoding of non-text documents.

### DIFF
--- a/sphinxserve/lib.py
+++ b/sphinxserve/lib.py
@@ -45,6 +45,10 @@ class Webserver(object):
         def after_request(response):
             '''Add reload javascript and remove googleapis fonts'''
             r = response
+            if not r.content_type.startswith('text/'):
+                # Let's not bother with post-processing non-text files
+                # like images, etc.
+                return r
             r.body = r.body.read().decode('utf-8') if getattr(
                 r.body, 'read', False) else r.body
             if r.content_type.startswith('text/html'):


### PR DESCRIPTION
When serving binary content, Sphinxserve will currently attempt to decode the body of the file as if it were UTF-8 bytes; when the file being served is in fact an image, this will cause a `UnicodeDecodeError` to be raised.

What this patch does is short-circuits post-processing of responses having non-text content-types.
