### PR TITLE
inject javascript at the very bottom of the page #8

### DIFF
--- a/sphinxserve/lib.py
+++ b/sphinxserve/lib.py
@@ -56,7 +56,7 @@ class Webserver(object):
             body = b''.join(r).decode('utf-8')
             r.close()
             if r.content_type.startswith('text/html'):
-                body = re.sub(r'(</head>)', r'{}\1'.format(reload_js),
+                body = re.sub(r'(</body>)', r'{}\1'.format(reload_js),
                     body, flags=re.IGNORECASE)
             if r.content_type.startswith('text/css'):
                 body = re.sub(r'@import url\(.+fonts.googleapis.com.+\);', '',


### PR DESCRIPTION
Resolves issue with the readthedocs theme, see also #8. Note that I haven't tested this against any other themes, although that should probably work just fine.